### PR TITLE
Update grpc-bus.proto to accept metadata

### DIFF
--- a/grpc-bus.proto
+++ b/grpc-bus.proto
@@ -46,9 +46,16 @@ message GBReleaseService {
   int32 service_id = 1;
 }
 
+message GBMetadataValues {
+  repeated string values = 1;
+}
+
 message GBCallInfo {
   string method_id = 1;
   bytes bin_argument = 2;
+  // Meta is a map from string to []string
+  // e.g: https://godoc.org/google.golang.org/grpc/metadata#MD
+  map<string, GBMetadataValues> metadata = 3;
 }
 
 // Create a call

--- a/server.js
+++ b/server.js
@@ -40,6 +40,11 @@ wss.on('connection', function connection(ws) {
       //var message = JSON.parse(data);
       var message = gbTree.GBClientMessage.decode(data);
       console.log('received (parsed):');
+      // We specify a constant depth here because the incoming
+      // message may contain the Metadata object, which has
+      // circular references and crashes console.dir if its
+      // allowed to recurse to print. Depth of 3 was chosen
+      // because it supplied enough detail when printing
       console.dir(message, { depth: 3 });
       gbServer.handleMessage(message);
     });

--- a/server.js
+++ b/server.js
@@ -40,7 +40,7 @@ wss.on('connection', function connection(ws) {
       //var message = JSON.parse(data);
       var message = gbTree.GBClientMessage.decode(data);
       console.log('received (parsed):');
-      console.dir(message, { depth: null });
+      console.dir(message, { depth: 3 });
       gbServer.handleMessage(message);
     });
   });


### PR DESCRIPTION
Also ... it seems w this change, some of the calls to `console.dir` are hitting recursive objects and killing the proxy ... so we may have to remove those. It's a bit unclear why exactly this change makes any of these objects recursive.
