### PR TITLE
migrate Dockerfile away from node:onbuild image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,7 @@
-FROM node:onbuild
+FROM node:8-alpine
+WORKDIR /app
+COPY package.json /app/package.json
+RUN npm install --production
+COPY server.js /app/server.js
+EXPOSE 8081
+CMD npm start


### PR DESCRIPTION
note: this (and the original) don't seem to be completing their build process at the moment